### PR TITLE
Add launch file and instructions for simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ There are additional arguments that you can use:
 Expected output: 
 [IMAGE]
 
+### Startup (simulation - experimental)
+
+> Make sure you installed [easy_panda_sim](https://github.com/hsp-panda/panda_ros_common)
+```
+roslaunch easy_panda_sim simulation.launch
+roslaunch panda_grasp_server grasp_server_sim.launch
+```
+
 ### Available commands
 
 You can send commands to the module over ROS services. Use the `rosservice [list | info]` command line tool to view them, the names are pretty straightforward. 

--- a/launch/grasp_server_sim.launch
+++ b/launch/grasp_server_sim.launch
@@ -1,0 +1,27 @@
+<launch>
+
+    <arg name="table_height"                            default="0.12" />
+    <!-- <arg name="start_realsense"                         default="true" /> -->
+    <!-- <arg name="rviz_config"                             default="rviz.rviz" /> -->
+
+    <!-- Start robot controllers, moveit and rviz -->
+    <include file="$(find panda_moveit_config)/launch/panda_control_moveit_rviz_sim.launch">
+        <!-- <arg name="rviz_command_args"               value="-d $(find panda_grasp_server)/rviz/$(arg rviz_config)" /> -->
+    </include>
+
+    <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+
+    <!-- Start the grasp and movement server node -->
+    <node name="panda_grasp_server" pkg="panda_grasp_server" type="panda_grasp_server_node" output="screen">
+        <param name="workspace/table_height"            value="$(arg table_height)" />
+        <!-- Table size and bench size are supposed to be x,y,z -->
+        <param name="workspace/table_size"              value="[1.0, 2.0, 0.8]" type="yaml" />
+        <param name="workspace/bench_size"              value="[0.6, 0.6, 0.6]" type="yaml"/>
+        <!-- Offset expressed in x,y coordinates with respect to the bench top surface center -->
+        <param name="workspace/bench_mount_xy"          value="[0.1, 0.0]" type="yaml"/>
+        <param name="planning/max_vel_scaling_factor"   value="0.3" />
+        <param name="planning/max_acc_scaling_factor"   value="0.3" />
+        <param name="planning/eef_link_id"              value="panda_tcp"/>
+    </node>
+
+</launch>


### PR DESCRIPTION
Add launch file `launch/grasp_server_sim.launch` supporting https://github.com/hsp-panda/easy_panda_sim and instructions in `README.md`