### PR TITLE
Add optional arg moveit_use_bio_ik to use bio_ik inverse kinematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ There are additional arguments that you can use:
 - `robot_ip:=<whatever_ip>` if the robot IP is not the default one
 - `rviz_config:=<custom_rviz_config_path>` if you want a custom rviz file
 - `load_gripper:=false` if you don't need the gripper
+- `moveit_use_bio_ik:=true` in order to use the [BioIK](https://github.com/TAMS-Group/bio_ik) inverse kinematic solver
 
 Expected output: (you may or may not have the ARUCO board detection set up)
 ![IMAGE](assets/home.png)

--- a/launch/grasp_server.launch
+++ b/launch/grasp_server.launch
@@ -10,11 +10,14 @@
 
     <arg name="enable_force_grasp"                      default="false" />
 
+    <arg name="moveit_use_bio_ik"                       default="false" />
+
     <!-- Start robot controllers, moveit and rviz -->
     <include file="$(find panda_moveit_config)/launch/panda_control_moveit_rviz.launch">
         <arg name="load_gripper"                    value="$(arg load_gripper)" />
         <arg name="robot_ip"                        value="$(arg robot_ip)" />
         <arg name="rviz_command_args"               value="-d $(find panda_grasp_server)/rviz/$(arg rviz_config)" />
+        <arg name="moveit_use_bio_ik"               value="$(arg moveit_use_bio_ik)" />
     </include>
 
     <!-- Start realsense, if necessary -->

--- a/launch/grasp_server_sim.launch
+++ b/launch/grasp_server_sim.launch
@@ -2,11 +2,13 @@
 
     <arg name="table_height"                            default="0.0" />
     <arg name="rviz_config"                             default="rviz.rviz" />
+    <arg name="moveit_use_bio_ik"                       default="false" />
     <!-- <arg name="start_realsense"                         default="true" /> -->
 
     <!-- Start robot controllers, moveit and rviz -->
     <include file="$(find panda_moveit_config)/launch/panda_control_moveit_rviz_sim.launch">
         <arg name="rviz_command_args"               value="-d $(find panda_grasp_server)/rviz/$(arg rviz_config)" />
+        <arg name="moveit_use_bio_ik"               value="$(arg moveit_use_bio_ik)" />
     </include>
 
     <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />


### PR DESCRIPTION
This PR add support for the [BioIK](https://github.com/TAMS-Group/bio_ik) inverse kinematics solver.

It also updates `README.md` in order to document the parameter `moveit_use_bio_ik` required to enable the solver.

Differently from KDL, this solver can and has been configured in order to avoid, as much as possible, joint limits. As side effect, this regularizes and removes undesired movements of joints that do not change the assigned 6D pose of the end effector.

**Do not merge before** https://github.com/hsp-panda/panda_moveit_config/pull/3