### PR TITLE
Implement integration with hsp-panda/xela-force-control

### DIFF
--- a/config/fc_grasp_demo_server_config.yaml
+++ b/config/fc_grasp_demo_server_config.yaml
@@ -39,3 +39,8 @@ ops_params/enable_force_grasp         : True # Enable force-based grasping
 ops_params/enable_graspa_stab_motion  : False # Enable graspa stability motion after grasping
 ops_params/enable_graspa_save_grasp   : False # Enable saving grasps in graspa-format
 ops_params/grasp_save_path            : "dumped_grasps"
+
+# Parameters dedicated to the ROBOTIQ_2F_FC gripper
+robotiq2f_force_controlled/force_target   : 0.0 # Force target used for the force trajectory
+robotiq2f_force_controlled/force_duration : 1.0 # Time length of the force trajectory going from 0.0 to 'robotiq2f_force_controlled/force_target'
+robotiq2f_force_controlled/error_threshold : 5.0 # Error threshold deciding if the grasp is successful

--- a/config/fc_grasp_demo_server_config.yaml
+++ b/config/fc_grasp_demo_server_config.yaml
@@ -33,7 +33,7 @@ planning/publish_rviz               : True # Weather to visualize trajectories
 # FRANKA_HAND
 # ROBOTIQ_2F
 # ROBOTIQ_2F_FC
-gripper/gripper_type                : "ROBOTIQ_2F"
+gripper/gripper_type                : "ROBOTIQ_2F_FC"
 
 ops_params/enable_force_grasp         : True # Enable force-based grasping
 ops_params/enable_graspa_stab_motion  : False # Enable graspa stability motion after grasping

--- a/src/panda_grasp_server/grippers.py
+++ b/src/panda_grasp_server/grippers.py
@@ -102,6 +102,11 @@ class GripperInterface(object):
     def get_gripper_status(self):
         pass
 
+    @abstractmethod
+    def reset(self):
+        """In case a gripper handler is stateful, we might want reset it."""
+        pass
+
     # Some utils methods
 
     def is_pos_in_bounds(self, pos):

--- a/src/panda_grasp_server/grippers.py
+++ b/src/panda_grasp_server/grippers.py
@@ -495,6 +495,7 @@ class Robotiq2FGripperForceControlled(Robotiq2FGripper):
 
         # Start the logger
         self.controller_logger_call(LoggerCommand.LOGGER_COMMAND_RUN)
+        self._is_logger_running = True
 
         # Start the force trajectory generator
         self.setpoint_service_call(force_target, force_duration)
@@ -512,7 +513,10 @@ class Robotiq2FGripperForceControlled(Robotiq2FGripper):
     def open_gripper(self, target_speed=_max_speed, wait=True):
 
         # Stop the logger and save data
-        self.controller_logger_call(LoggerCommand.LOGGER_COMMAND_SAVE)
+        if self._is_logger_running:
+            self.controller_logger_call(LoggerCommand.LOGGER_COMMAND_SAVE)
+            self.controller_logger_call(LoggerCommand.LOGGER_COMMAND_STOP)
+            self._is_logger_running = False
 
         # Stop the force controller
         self.controller_service_call(ControllerStatus.CONTROLLER_STATUS_STOPPED)

--- a/src/panda_grasp_server/grippers.py
+++ b/src/panda_grasp_server/grippers.py
@@ -248,6 +248,11 @@ class FrankaHandGripper(GripperInterface):
     def get_gripper_status(self):
         raise NotImplementedError
 
+    def reset(self):
+        """Does nothing."""
+        pass
+
+
 class Robotiq2FGripper(GripperInterface):
     """Wrapper class for the Robotiq 2F Gripper class.
 
@@ -378,6 +383,10 @@ class Robotiq2FGripper(GripperInterface):
     def get_gripper_status(self):
         raise NotImplementedError
 
+    def reset(self):
+        """Does nothing."""
+        pass
+
 class Robotiq2FGripperForceControlled(Robotiq2FGripper):
     """ Wrapper class for the Robotiq 2F Gripper class with an added force
     control loop on top.
@@ -441,6 +450,9 @@ class Robotiq2FGripperForceControlled(Robotiq2FGripper):
 
         # Set a default value for the force feedback
         self._force_feedback = 0.0
+
+        # Whether the data logger is running or not
+        self._is_logger_running = False
 
     def grasp_motion(self, target_width=_min_width, target_speed=_min_speed, target_force=_min_force, wait=True, duration=10.0):
 
@@ -602,3 +614,11 @@ class Robotiq2FGripperForceControlled(Robotiq2FGripper):
 
         with self._mutex:
             self._force_feedback = data.data
+
+
+    def reset(self):
+
+        # Reset state variables
+        self._object_contact_position = -1
+        self._force_feedback = 0.0
+        self._is_logger_running = False

--- a/src/panda_grasp_server/panda_grasp_server.py
+++ b/src/panda_grasp_server/panda_grasp_server.py
@@ -597,6 +597,9 @@ class PandaActionServer(object):
 
     def grasp(self, width, velocity=0.5, force=20):
 
+        # Reset the gripper handler in case of a stateful one
+        self._gripper.reset()
+
         # Execute grasp directly with the gripper action server
         # Different behaviour according to the enable_force_grasp flag
         if self._enable_force_grasp:


### PR DESCRIPTION
This implements force control within the `panda-grasp-server` `fc_grasp_demo` branch as follows:
- it forces the `gripper/gripper_type` in the configuration file to `ROBOTIQ_2F_FC`
- update implementation of `GripperInterface` and `Robotiq2FGripperForceControlled` in order to properly communicate with the [xela-force-control](https://github.com/hsp-panda/xela-force-control)
- adds a method `reset()` in the `GripperInterface` and implements it for all the gripper handlers
> this does nothing for all the gripper handlers except for `Robotiq2FGripperForceControlled`, where it is required to reset some state variables
- call the method `reset()` on the gripper handler within the `PandaActionServer::grasp()` method before initiating a new grasp